### PR TITLE
wip - Count tries & save click history

### DIFF
--- a/src/common/components/Card/Card.js
+++ b/src/common/components/Card/Card.js
@@ -11,7 +11,7 @@ export const Card = ({ card, onClick, children }) => {
 
   return (
     <article className={cardClassName} onClick={onClick}>
-      <span className={styles.card__face}> {children} </span>{" "}
+      <span className={styles.card__face}>{card.face}</span>
     </article>
   );
 };

--- a/src/common/utils/flipCard.js
+++ b/src/common/utils/flipCard.js
@@ -1,4 +1,4 @@
-export const flipCard = (card, bool) => {
+export const flipCard = (card, bool = !card.isFaceUp) => {
   const newCard = {
     ...card,
     // isFaceUp: !card.isFaceUp

--- a/src/common/utils/flipCard.js
+++ b/src/common/utils/flipCard.js
@@ -1,7 +1,8 @@
-export const flipCard = card => {
+export const flipCard = (card, bool) => {
   const newCard = {
     ...card,
-    isFaceUp: !card.isFaceUp
+    // isFaceUp: !card.isFaceUp
+    isFaceUp: bool
   };
   return newCard;
 };

--- a/src/common/utils/flipCard.js
+++ b/src/common/utils/flipCard.js
@@ -1,8 +1,7 @@
-export const flipCard = (card, bool = !card.isFaceUp) => {
+export const flipCard = (card, isFaceUp = !card.isFaceUp) => {
   const newCard = {
     ...card,
-    // isFaceUp: !card.isFaceUp
-    isFaceUp: bool
+    isFaceUp
   };
   return newCard;
 };

--- a/src/core/Board.js
+++ b/src/core/Board.js
@@ -9,52 +9,65 @@ import styles from "./Board.module.scss";
 export const Board = () => {
   const [shuffledCards, setShuffledCards] = useState(cardFaces());
   const [inputTracker, setInputTracker] = useState([]);
+  const [turnCounter, setTurnCounter] = useState(0);
+  const [matchCounter, setMatchCounter] = useState(0);
+
+  const compareCards = compareArray => {
+    const firstCard = shuffledCards[compareArray[0]].name;
+    const secondCard = shuffledCards[compareArray[1]].name;
+    console.log(firstCard, secondCard);
+
+    if (firstCard === secondCard) {
+      setMatchCounter(matchCounter + 1);
+    } else {
+      setTimeout(() => {
+        const newUpdatedCards = [...shuffledCards];
+        compareArray.forEach(cardIndex => {
+          newUpdatedCards[cardIndex] = flipCard(
+            newUpdatedCards[cardIndex],
+            false
+          );
+        });
+        setShuffledCards(newUpdatedCards);
+      }, 1000);
+    }
+  };
 
   const handleFlip = (key, card) => {
     if (!card.isFaceUp) {
       const updatedCards = [...shuffledCards];
-      updatedCards[key] = flipCard(card);
+      const updatedTracker = [...inputTracker];
+      updatedCards[key] = flipCard(card, true);
       setShuffledCards(updatedCards);
-      if (inputTracker.length === 0) {
-        setInputTracker([
-          {
-            index: `${key}`,
-            name: `${card.name}`
-          }
-        ]);
+      if (inputTracker[turnCounter] === undefined) {
+        updatedTracker[turnCounter] = [key];
       } else {
-        if (inputTracker[0].name === card.name) {
-          console.log(inputTracker[0].name, card.name, "PAIR");
-        } else {
-          setTimeout(() => {
-            console.log(inputTracker[0].name, card.name, "NOPE");
-            updatedCards[inputTracker[0].index] = flipCard(
-              updatedCards[inputTracker[0].index]
-            );
-            updatedCards[key] = flipCard(updatedCards[key]);
-            setShuffledCards(updatedCards);
-          }, 500);
-        }
-        setInputTracker([]);
+        updatedTracker[turnCounter][1] = key;
+        setTurnCounter(turnCounter + 1);
+        compareCards(updatedTracker[turnCounter]);
       }
-    } else {
-      console.log("no way buddy!");
+      setInputTracker(updatedTracker);
     }
   };
 
   return (
-    <div className={styles.board}>
-      {shuffledCards.map((card, i) => (
-        <Card
-          card={card}
-          key={i}
-          onClick={() => {
-            handleFlip(i, card);
-          }}
-        >
-          {card.face}
-        </Card>
-      ))}
-    </div>
+    <>
+      <p>
+        Tries: {turnCounter}, Matches: {matchCounter}
+      </p>
+      <div className={styles.board}>
+        {shuffledCards.map((card, i) => (
+          <Card
+            card={card}
+            key={i}
+            onClick={() => {
+              handleFlip(i, card);
+            }}
+          >
+            {card.face}
+          </Card>
+        ))}
+      </div>
+    </>
   );
 };

--- a/src/core/Board.js
+++ b/src/core/Board.js
@@ -37,7 +37,7 @@ export const Board = () => {
     if (!card.isFaceUp) {
       const updatedCards = [...shuffledCards];
       const updatedTracker = [...inputTracker];
-      updatedCards[key] = flipCard(card, true);
+      updatedCards[key] = flipCard(card);
       setShuffledCards(updatedCards);
       if (inputTracker[turnCounter] === undefined) {
         updatedTracker[turnCounter] = [key];

--- a/src/core/Board.js
+++ b/src/core/Board.js
@@ -56,16 +56,14 @@ export const Board = () => {
         Tries: {turnCounter}, Matches: {matchCounter}
       </p>
       <div className={styles.board}>
-        {shuffledCards.map((card, i) => (
+        {shuffledCards.map((card, cardIndex) => (
           <Card
             card={card}
-            key={i}
+            key={cardIndex}
             onClick={() => {
-              handleFlip(i, card);
+              handleFlip(cardIndex, card);
             }}
-          >
-            {card.face}
-          </Card>
+          />
         ))}
       </div>
     </>


### PR DESCRIPTION
## What Changed & Why?
I updated the code so that the app counts the number of user tries and saves a history of the users clicks which each try as an object of two array indices. The way I had it before there was only one variable tracking the last click, and if the user clicked multiple times in a row, then the app would compare the wrong values. 

The drawback is I'm storing an ever-growing array of information that stops being relevant pretty quickly. Not sure if that's a problem, but it doesn't feel like the most elegant solution. 

Still to resolve: how to update the state of the cards that I am comparing without affecting the rest of the deck. As I have it now, if the user clicks multiples of greater than two then things quickly go wonky.

I also updated `flipCard.js` so that you can pass an explicit true or false to `card.isFaceUp`. By default it will just set this value to the opposite of its current value.

## Screenshots / Videos
In a perfect world: 
![compare-2](https://user-images.githubusercontent.com/35696879/71186457-3c6eb000-224b-11ea-942f-0e6a4522bfda.gif)

But it breaks down if the user is human
![compare-2-bad](https://user-images.githubusercontent.com/35696879/71186472-45f81800-224b-11ea-9140-d57a1ff42dff.gif)

### Checklist
- [x] Functionally and visually tested in Firefox, Safari, and Chrome
- [x] No console warnings or errors
